### PR TITLE
Improve game output, fix split/payout bugs, and add late-join queuing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run Commands
+
+```bash
+# Build (produces shaded fat JAR)
+mvn package
+
+# Run all tests
+mvn test
+
+# Run a single test class
+mvn test -Dtest=HandTest
+
+# Run a single test method
+mvn test -Dtest=HandTest#testAddCard
+
+# Run the application (after building)
+java -jar target/wavy-cards-1.0-SNAPSHOT.jar
+
+# Run without building a JAR
+mvn exec:java -Dexec.mainClass=blackjack.MultiserverManager
+```
+
+The application is interactive: it prompts to either host (option 1) or join (option 2) a game. Hosting requires a player count (1–8) and a port; joining requires the host's IP and port.
+
+## Architecture
+
+### Client-Server over TCP Sockets
+
+The game is split into a server process and one or more client processes that communicate over raw TCP sockets. All messages are newline-delimited JSON strings. Both ends use Jackson to produce/consume JSON.
+
+**Server side** (`blackjack` package):
+- `MultiserverManager` — entry point; forks into `Server.main()` or `Client.main()`.
+- `Server` — opens a `ServerSocket`, spawns one `PlayerManager` thread per accepted connection, and runs a `serverConsole` thread for admin commands.
+- `PlayerManager` — one instance per connected client. Reads raw lines from the socket and routes them to `player.setTurnResponse()` or `player.setBetResponse()` depending on which phase the player is in. Starts the `Play` game thread when enough players are connected.
+- `Play` — implements `Runnable`; orchestrates rounds: collect bets → deal → each player's turn → dealer's turn → payouts → reset → repeat.
+
+**Client side** (`blackjack.Client` package):
+- `Client` — connects to the server socket. Spawns a read thread (`handleResponse`) that receives and prints server messages, while the main thread reads stdin and sends responses. Message routing is driven by `serverRequestType`, which is updated on each incoming message.
+- `GuiClient` — stub; not yet implemented or wired into the menu.
+
+### JSON Protocol
+
+`protocolType` field determines the message kind:
+
+| protocolType | Direction | Purpose |
+|---|---|---|
+| `general` | S→C | Plain text notification |
+| `connectedUpdate` | S→C | Sent after name is accepted; includes starting money |
+| `turnRequest` | S→C | Sent to the active player; lists available actions |
+| `update` | S→C | Full game state snapshot (all players + dealer) |
+| `betRequest` | S→C | Prompts the player for a bet amount |
+| `turnResponse` | C→S | Player's chosen action (`{"action": "hit"}`) |
+| `betResponse` | C→S | Player's bet (`{"bet": 100}`) |
+
+Example messages are in `example/protocol/`.
+
+**Server protocol classes:** `blackjack.protocol.GenerateJson` (produce) and `DecryptJson` (consume).  
+**Client protocol classes:** `blackjack.Client.protocol.Generate` (produce) and `Decrypt` (consume).
+
+### Game State Machine
+
+`Hand` holds a `handState` (interface in `blackjack.player.state`). The state controls which actions are available and transitions happen automatically when cards are added:
+
+- `Normal` → the only state where player actions are accepted. `getActions(Hand)` returns Hit, Stand, Double, Surrender, and optionally Split (only when the two starting cards have equal value and the hand hasn't already been split).
+- `Bust` → hand value exceeded 21; turn ends immediately.
+- `BlackJack` → exactly 21 on the first two cards; automatic payout at 1.5×.
+- `Stand` → player chose to stand; turn ends.
+- `Surrender` → player surrendered; half-bet returned.
+
+### Actions (Strategy Pattern)
+
+`BlackJackAction` is an abstract class with `execute(Hand, Player, Play)`. Concrete actions are in `blackjack.actions`. `BlackJackAction.create(String)` is the factory used by `DecryptJson` to instantiate the player's chosen action.
+
+### Turn Polling (Known Design Issue)
+
+`Player.manageTurn()` and `manageBet()` use a busy-wait `Thread.sleep(1000)` loop, spinning until `turnResponse` / `betResponse` is set by `PlayerManager`'s read thread. This is the current synchronization mechanism — no `wait()`/`notify()` or `BlockingQueue` is used.
+
+### Known Static Field Bugs
+
+- `Deck.PLAY_DECK` is `static` — shared across all `Deck` instances.
+- `Play.players` is `static` — shared across all `Play` instances (rounds).
+
+Both are latent correctness issues when multiple games/rounds are involved.
+
+## Package Layout
+
+```
+blackjack/
+  MultiserverManager.java     # Entry point
+  Server.java                 # Server socket + admin console
+  PlayerManager.java          # Per-client socket handler
+  Play.java                   # Round orchestration
+  Client/
+    Client.java               # Terminal client
+    GuiClient.java            # Swing GUI stub (empty)
+    protocol/
+      Generate.java           # Client → server JSON builders
+      Decrypt.java            # Server → client JSON parsers
+    Util/
+      Atlas.java              # Sprite-sheet loader (for GUI)
+      PreloadedAtlas.java
+  actions/                    # BlackJackAction subclasses
+  deck/                       # Card, Deck, UnicodeCards
+  player/
+    Player.java
+    Dealer.java
+    Hand.java
+    state/                    # handState interface + implementations
+  protocol/                   # Server-side JSON builders/parsers
+    Exceptions/               # InvalidAction, InvalidBet
+```
+
+Card sprites are in `src/main/resources/Deck/` (PNG + XML atlas).

--- a/example/protocol/server->client/general.json
+++ b/example/protocol/server->client/general.json
@@ -1,4 +1,3 @@
 {
-  "protocolType": "general",
-  "message": "string"
-}
+  "protocolType": "general", "message": "string"
+ 

--- a/src/main/java/blackjack/Client/Client.java
+++ b/src/main/java/blackjack/Client/Client.java
@@ -18,7 +18,7 @@ public class Client {
     private BufferedWriter out;
     private BufferedReader in;
     private String name;
-    private String serverRequestType;
+    private volatile String serverRequestType = "general";
 
     public Client(Socket socket) {
         try {
@@ -100,9 +100,9 @@ public class Client {
             String messageToSend = scanner.nextLine();
 
             if (serverRequestType.equals("turnRequest")) {
-                sendMessage(Generate.generateTurnResponse(name, messageToSend));
+                sendMessage(Generate.generateTurnResponse(name, messageToSend.trim().toLowerCase()));
             } else if (serverRequestType.equals("betRequest")) {
-                checkBet(messageToSend);
+                checkBet(messageToSend.trim());
             } else {
                 sendMessage(messageToSend);
             }

--- a/src/main/java/blackjack/Client/protocol/Decrypt.java
+++ b/src/main/java/blackjack/Client/protocol/Decrypt.java
@@ -3,37 +3,76 @@ package blackjack.Client.protocol;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Iterator;
+import java.util.Map;
 
 public class Decrypt {
 
     public static JsonNode decryptServerMessage(String serverMessage) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode messageNode = mapper.readTree(serverMessage);
-
-        return messageNode;
+        return mapper.readTree(serverMessage);
     }
 
     public static String getAvailableActions(JsonNode protocolNode) {
         JsonNode actionsNode = protocolNode.get("actions");
-        String actionMessage = "Available actions:\n";
-
+        StringBuilder sb = new StringBuilder();
+        sb.append("\n*** YOUR TURN ***\n");
+        sb.append("Actions: ");
+        boolean first = true;
         for (JsonNode action : actionsNode) {
-            actionMessage += action.asText() + "\n";
+            if (!first) sb.append(", ");
+            sb.append(action.asText());
+            first = false;
+        }
+        sb.append("\nEnter action: ");
+        return sb.toString();
+    }
+
+    public static String getPlayerCardInfo(JsonNode protocolNode, String myName) {
+        StringBuilder sb = new StringBuilder();
+        String currentPlayer = protocolNode.get("currentPlayer").asText();
+
+        sb.append("\n─────────────────────────────────────\n");
+
+        JsonNode dealer = protocolNode.get("dealer");
+        String dealerHand = formatHand(dealer.get("hand"));
+        int dealerValue = dealer.get("handValue").asInt();
+        sb.append(String.format("  Dealer: %-20s [%d]%n", dealerHand, dealerValue));
+
+        sb.append("  ─────────────────────────────────\n");
+
+        Iterator<Map.Entry<String, JsonNode>> players = protocolNode.get("players").fields();
+        while (players.hasNext()) {
+            Map.Entry<String, JsonNode> entry = players.next();
+            String pName = entry.getKey();
+            JsonNode p = entry.getValue();
+            String hand = formatHand(p.get("hand"));
+            int value = p.get("handValue").asInt();
+            int money = (int) p.get("money").asDouble();
+            int bet = (int) p.get("bet").asDouble();
+            String state = p.get("state").asText();
+
+            String label = pName.equals(myName) ? pName + " (you)" : pName;
+            String turnMark = pName.equals(currentPlayer) ? " <" : "  ";
+            String stateMark = state.equals("normal") ? "" : " [" + state.toUpperCase() + "]";
+            sb.append(String.format("  %-18s %s  %-18s [%d]  $%d  bet: $%d%s%n",
+                    label, turnMark, hand, value, money, bet, stateMark));
         }
 
-        return actionMessage;
+        sb.append("─────────────────────────────────────");
+        return sb.toString();
     }
 
     public static String getTurn(JsonNode protocolNode) {
-        String currentPlayer = protocolNode.get("currentPlayer").asText();
-
-        return currentPlayer + "'s turn.";
+        return protocolNode.get("currentPlayer").asText() + "'s turn.";
     }
 
-    public static String getPlayerCardInfo(JsonNode protocolNode, String name) {
-        String cards = protocolNode.get("players").get(name).get("hand").toString();
-
-        return cards;
+    private static String formatHand(JsonNode handNode) {
+        StringBuilder sb = new StringBuilder();
+        for (JsonNode card : handNode) {
+            if (sb.length() > 0) sb.append("  ");
+            sb.append(card.asText());
+        }
+        return sb.toString();
     }
-
 }

--- a/src/main/java/blackjack/MultiserverManager.java
+++ b/src/main/java/blackjack/MultiserverManager.java
@@ -162,7 +162,12 @@ public class MultiserverManager {
         }
 
         System.out.print("Enter the PORT number of the server you want to join: ");
-        PORT = Integer.parseInt(scanner.nextLine().trim().strip());
+        try {
+            PORT = Integer.parseInt(scanner.nextLine().trim().strip());
+        } catch (NumberFormatException e) {
+            System.out.println("Invalid port number.");
+            IP = "";
+        }
     }
 
 }

--- a/src/main/java/blackjack/Play.java
+++ b/src/main/java/blackjack/Play.java
@@ -3,6 +3,7 @@ package blackjack;
 import java.util.ArrayList;
 import java.util.List;
 
+import blackjack.deck.Card;
 import blackjack.deck.Deck;
 import blackjack.player.Dealer;
 import blackjack.player.Hand;
@@ -10,6 +11,7 @@ import blackjack.player.Player;
 import blackjack.player.state.BlackJack;
 import blackjack.player.state.Bust;
 import blackjack.player.state.Stand;
+import blackjack.player.state.Surrender;
 import blackjack.protocol.GenerateJson;
 
 /**
@@ -17,6 +19,8 @@ import blackjack.protocol.GenerateJson;
  */
 public class Play implements Runnable {
     public static List<Player> players = new ArrayList<>();
+    private static final List<Player> pendingPlayers = new ArrayList<>();
+    private static volatile boolean roundInProgress = false;
     private volatile boolean running = true;
     private static Dealer dealer;
     private static int numPlayers;
@@ -51,6 +55,13 @@ public class Play implements Runnable {
      */
     @Override
     public void run() {
+        synchronized (Play.class) {
+            for (Player p : pendingPlayers) {
+                p.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage("Round starting — you're in!"));
+                players.add(p);
+            }
+            pendingPlayers.clear();
+        }
         if (deck.getPlayDeck().size() < numPlayers*5) {
             setupDeck();
         }
@@ -70,12 +81,13 @@ public class Play implements Runnable {
      */
     public void startGame() {
         dealInitialCards();
-        broadcastToAllPlayers(GenerateJson.generateUpdate(this));
+        pause(600);
+        broadcastToAllPlayers(GenerateJson.generateUpdate(this, true));
+        pause(800);
         for (Player player : players) {
             player.removeBet();
             if (player.getCardsInHand().getState() instanceof BlackJack) {
-                player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage("You got blackjack!"));
-                player.blackJackPayout();
+                player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage("You got blackjack! Waiting for dealer..."));
             }
             System.out.println(player);
         }
@@ -89,16 +101,27 @@ public class Play implements Runnable {
                 if (player.getIsSplit()) {
                     player.removeBet();
                     player.setIsSplit(false);
-                    for (Hand hand : player.getSplitPlay()) {
+                    for (int i = 0; i < player.getSplitPlay().size(); i++) {
+                        Hand hand = player.getSplitPlay().get(i);
                         hand.setBeanSplit(true);
-                        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage("Current playing hand: " + hand));
+                        pause(500);
+                        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(
+                            "Playing split hand " + (i + 1) + ": " + formatCards(hand.getCards()) + "  [" + hand.getValue() + "]"));
                         player.manageTurn(hand, this);
+                        if (player.getIsSplit()) {
+                            player.removeBet();
+                            player.setIsSplit(false);
+                        }
                     }
                 }
             }
-            broadcastToAllPlayers(GenerateJson.generateUpdate(this));
+            pause(800);
+            broadcastToAllPlayers(GenerateJson.generateUpdate(this, false));
+            pause(1000);
             dealerTurn();
+            pause(600);
             payout();
+            pause(800);
             stopGame();
         }
         this.run();
@@ -108,25 +131,35 @@ public class Play implements Runnable {
      * Loops through players in the game and calls the method to manage the bet chosen by each player.
      */
     private void getBets() {
+        roundInProgress = true;
         for (Player player : players) {
             player.manageBet();
         }
     }
 
     /**
-     * Adds a player to the game.
+     * Adds a player to the game. Routes to pendingPlayers during an active round.
      * @param player --> the player to add to the game.
      */
-    public static void addPlayer(Player player) {
-        players.add(player);
+    public static synchronized void addPlayer(Player player) {
+        if (roundInProgress) {
+            pendingPlayers.add(player);
+            player.getPlayerManager().sendMessage(
+                GenerateJson.generateGeneralMessage("A round is already in progress. You'll join at the start of the next round."));
+        } else {
+            players.add(player);
+        }
     }
 
     /**
-     * Removes a player from the game.
+     * Removes a player from the game (active or pending).
      * @param player --> the player to remove from the game.
      */
     public void removePlayer(Player player) {
         players.remove(player);
+        synchronized (Play.class) {
+            pendingPlayers.remove(player);
+        }
     }
 
     /**
@@ -149,18 +182,42 @@ public class Play implements Runnable {
      * Handles the dealers turn.
      */
     public void dealerTurn() {
-        broadcastToAllPlayers(GenerateJson.generateGeneralMessage("Dealer's turn."));
-        broadcastToAllPlayers(GenerateJson.generateGeneralMessage("Initial cards: " + dealer.toString()));
+        broadcastToAllPlayers(GenerateJson.generateGeneralMessage("--- Dealer's Turn ---"));
+        pause(800);
         while (dealer.getCardsInHand().getValue() < 17) {
-            dealer.getCardsInHand().addCard(deck.deal());
-            broadcastToAllPlayers(GenerateJson.generateGeneralMessage(dealer.toString()));
+            Card drawn = deck.deal();
+            dealer.getCardsInHand().addCard(drawn);
+            broadcastToAllPlayers(GenerateJson.generateGeneralMessage(
+                "Dealer draws " + drawn + "  →  " + formatCards(dealer.getCardsInHand().getCards()) + "  [" + dealer.getCardsInHand().getValue() + "]"));
+            pause(900);
         }
-        if (dealer.getCardsInHand().getValue() > 21) {
+        int finalValue = dealer.getCardsInHand().getValue();
+        String finalHand = formatCards(dealer.getCardsInHand().getCards());
+        if (finalValue > 21) {
             dealer.setBust(true);
-            broadcastToAllPlayers(GenerateJson.generateGeneralMessage("Dealer busts with " + dealer.getCardsInHand().getValue() + "!"));
+            broadcastToAllPlayers(GenerateJson.generateGeneralMessage(
+                "Dealer busts!  " + finalHand + "  [" + finalValue + "]"));
         } else {
-            broadcastToAllPlayers(GenerateJson.generateGeneralMessage("Dealer stands on " + dealer.getCardsInHand().getValue() + "."));
+            broadcastToAllPlayers(GenerateJson.generateGeneralMessage(
+                "Dealer stands on " + finalValue + ".  " + finalHand));
         }
+    }
+
+    private void pause(int ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private String formatCards(List<Card> cards) {
+        StringBuilder sb = new StringBuilder();
+        for (Card c : cards) {
+            if (sb.length() > 0) sb.append("  ");
+            sb.append(c);
+        }
+        return sb.toString();
     }
 
     /**
@@ -182,10 +239,18 @@ public class Play implements Runnable {
      * @param hand --> their current hand.
      */
     private void determinePayout(Player player, Hand hand) {
-        if (dealer.getBust() && hand.getState() instanceof Stand) {
-            player.winBet();
+        if (hand.getState() instanceof BlackJack) {
+            if (dealer.getCardsInHand().getState() instanceof BlackJack) {
+                player.pushBet();
+            } else {
+                player.blackJackPayout();
+            }
+        } else if (hand.getState() instanceof Surrender) {
+            // already settled in Player.bustOrSurrendered()
         } else if (hand.getState() instanceof Bust) {
             player.loseBet();
+        } else if (dealer.getBust()) {
+            player.winBet();
         } else {
             handleCardAnalysis(player, hand);
         }
@@ -235,7 +300,8 @@ public class Play implements Runnable {
      */
     public void stopGame() {
         running = false;
-        broadcastToAllPlayers(GenerateJson.generateGeneralMessage("\nStopping round..."));
+        roundInProgress = false;
+        broadcastToAllPlayers(GenerateJson.generateGeneralMessage("\n═══════════════════════════════════════\n           Round complete!\n═══════════════════════════════════════"));
         for (Player player : players) {
             player.reset();
         }

--- a/src/main/java/blackjack/PlayerManager.java
+++ b/src/main/java/blackjack/PlayerManager.java
@@ -51,22 +51,24 @@ public class PlayerManager implements Runnable {
             if (players.size() > maxPlayers) {
                 sendMessage(GenerateJson.generateGeneralMessage("Table full."));
                 closeEverything(socket, in, out);
+                return;
             }
 
             chooseName();
 
-            while (true) {
-                if (Server.getGameOn()) {
+            synchronized (Server.class) {
+                if (!Server.getGameOn()) {
+                    Server.setGameOn(true);
                     new Thread(game).start();
                 }
+            }
 
-                while ((clientMessage = in.readLine()) != null) {
-                    if (player.isTurn()) {
-                        System.out.println(clientMessage);
-                        player.setTurnResponse(clientMessage);
-                    } else if (player.getIsChoosingBet()){
-                        player.setBetResponse(clientMessage);
-                    }
+            while ((clientMessage = in.readLine()) != null) {
+                if (player.isTurn()) {
+                    System.out.println(clientMessage);
+                    player.setTurnResponse(clientMessage);
+                } else if (player.getIsChoosingBet()) {
+                    player.setBetResponse(clientMessage);
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/blackjack/Server.java
+++ b/src/main/java/blackjack/Server.java
@@ -95,9 +95,6 @@ public class Server {
                 PlayerManager playerManager = new PlayerManager(socket, playerNum);
                 Thread handlerThread = new Thread(playerManager);
                 handlerThread.start();
-                if (playerNum == playerManager.getPlayers().size()) {
-                    gameOn = true;
-                }
             }
         } catch (IOException e) {
             System.out.println(e.getMessage());
@@ -107,6 +104,10 @@ public class Server {
 
     public static boolean getGameOn() {
         return gameOn;
+    }
+
+    public static synchronized void setGameOn(boolean value) {
+        gameOn = value;
     }
 
     public static Play getGame() {

--- a/src/main/java/blackjack/actions/BlackJackAction.java
+++ b/src/main/java/blackjack/actions/BlackJackAction.java
@@ -1,10 +1,12 @@
 package blackjack.actions;
 
 import blackjack.Play;
+import blackjack.deck.Card;
 import blackjack.player.Hand;
 import blackjack.player.Player;
 import blackjack.protocol.Exceptions.InvalidAction;
 
+import java.util.List;
 import java.util.Objects;
 
 
@@ -32,6 +34,15 @@ public abstract class BlackJackAction {
     @Override
     public int hashCode() {
         return Objects.hashCode(actionName);
+    }
+
+    protected static String formatHand(Hand hand) {
+        StringBuilder sb = new StringBuilder();
+        for (Card c : hand.getCards()) {
+            if (sb.length() > 0) sb.append("  ");
+            sb.append(c);
+        }
+        return sb.toString();
     }
 
     public static BlackJackAction create(String actionName) throws InvalidAction {

--- a/src/main/java/blackjack/actions/DoubleAction.java
+++ b/src/main/java/blackjack/actions/DoubleAction.java
@@ -1,6 +1,7 @@
 package blackjack.actions;
 
 import blackjack.Play;
+import blackjack.deck.Card;
 import blackjack.player.Hand;
 import blackjack.player.Player;
 import blackjack.player.state.Bust;
@@ -15,10 +16,11 @@ public class DoubleAction extends BlackJackAction {
     @Override
     public void execute(Hand playingHand, Player player, Play game) {
         player.doubleBet();
-        playingHand.setState(playingHand.addCard(game.getDeck().deal()));
+        Card drawn = game.getDeck().deal();
+        playingHand.setState(playingHand.addCard(drawn));
         System.out.println(player.getName() + " doubles.");
-        // TODO idk what to do, you can choose \/
-        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(player.toString()));
+        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(
+            "Doubled! Drew " + drawn + "  →  " + formatHand(playingHand) + "  [" + playingHand.getValue() + "]"));
 
         switch (playingHand.getState().toString()) {
             case "normal":

--- a/src/main/java/blackjack/actions/HitAction.java
+++ b/src/main/java/blackjack/actions/HitAction.java
@@ -1,6 +1,7 @@
 package blackjack.actions;
 
 import blackjack.Play;
+import blackjack.deck.Card;
 import blackjack.player.Hand;
 import blackjack.player.Player;
 import blackjack.protocol.GenerateJson;
@@ -12,9 +13,11 @@ public class HitAction extends BlackJackAction {
 
     @Override
     public void execute(Hand playingHand, Player player, Play game) {
-        playingHand.setState(playingHand.addCard(game.getDeck().deal()));
+        Card drawn = game.getDeck().deal();
+        playingHand.setState(playingHand.addCard(drawn));
         System.out.println(player.getName() + " hits.");
-        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(player.toString()));
+        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(
+            "Drew " + drawn + "  →  " + formatHand(playingHand) + "  [" + playingHand.getValue() + "]"));
     }
 
     @Override

--- a/src/main/java/blackjack/actions/SplitAction.java
+++ b/src/main/java/blackjack/actions/SplitAction.java
@@ -21,10 +21,12 @@ public class SplitAction extends BlackJackAction {
      */
     @Override
     public void execute(Hand playingHand, Player player, Play game) {
-        Hand splitPlayerHand = player.splitHand(game);
+        Hand splitPlayerHand = player.splitHand(game, playingHand);
         System.out.println(player.getName() + " splits.");
-        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(player.getCardsInHand().toString()));
-        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(splitPlayerHand.toString()));
+        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(
+            "Hand 1: " + formatHand(playingHand) + "  [" + playingHand.getValue() + "]"));
+        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(
+            "Hand 2: " + formatHand(splitPlayerHand) + "  [" + splitPlayerHand.getValue() + "]"));
     }
 
     @Override

--- a/src/main/java/blackjack/actions/StandAction.java
+++ b/src/main/java/blackjack/actions/StandAction.java
@@ -15,7 +15,8 @@ public class StandAction extends BlackJackAction {
     @Override
     public void execute(Hand playingHand, Player player, Play game) {
         System.out.println(player.getName() + " stands.");
-        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(player.toString()));
+        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(
+            "You stand on " + playingHand.getValue() + "."));
         if (playingHand.getState() instanceof Normal) {
             playingHand.setState(new Stand());
         }

--- a/src/main/java/blackjack/actions/SurrenderAction.java
+++ b/src/main/java/blackjack/actions/SurrenderAction.java
@@ -4,7 +4,6 @@ import blackjack.Play;
 import blackjack.player.Hand;
 import blackjack.player.Player;
 import blackjack.player.state.Surrender;
-import blackjack.protocol.GenerateJson;
 
 public class SurrenderAction extends BlackJackAction {
     public SurrenderAction() {
@@ -16,7 +15,6 @@ public class SurrenderAction extends BlackJackAction {
         player.surrender();
         playingHand.setState(new Surrender());
         System.out.println(player.getName() + " surrenders.");
-        player.getPlayerManager().sendMessage(GenerateJson.generateGeneralMessage(player.toString()));
     }
 
     @Override

--- a/src/main/java/blackjack/player/Player.java
+++ b/src/main/java/blackjack/player/Player.java
@@ -76,7 +76,7 @@ public class Player {
         while (playerHand.getState() instanceof Normal) {
             this.setTurn(true);
 
-            this.actions = playerHand.getState().getActions(cardsInHand);
+            this.actions = playerHand.getState().getActions(playerHand);
 
             String turnRequest = GenerateJson.generateTurnRequest(this, playerHand);
             playerManager.sendMessage(turnRequest);
@@ -122,14 +122,13 @@ public class Player {
      */
     private void bustOrSurrendered(Hand playerHand) {
         if (playerHand.getState() instanceof Bust) {
-            playerManager.sendMessage(GenerateJson.generateGeneralMessage("You have been busted! \n" +
-                    "You have lost your bet of $" + bet + "\n" +
-                    "Money remaining: " + money));
+            playerManager.sendMessage(GenerateJson.generateGeneralMessage("Bust! You lost your bet of $" + (int) bet + "\n" +
+                    "Balance: $" + (int) money));
         }
         if (playerHand.getState() instanceof Surrender) {
             this.surrenderPayout();
-            playerManager.sendMessage(GenerateJson.generateGeneralMessage("You have lost half your bet: $" + bet + "\n" +
-                    "Money remaining: " + money));
+            playerManager.sendMessage(GenerateJson.generateGeneralMessage("Surrendered — half bet returned: $" + (int) bet + "\n" +
+                    "Balance: $" + (int) money));
         }
     }
 
@@ -138,19 +137,21 @@ public class Player {
      * @param game the current game the player is a part of.
      * @return secondHand created from the original hand.
      */
-    public Hand splitHand(Play game) {
+    public Hand splitHand(Play game, Hand handToSplit) {
         isSplit = true;
         Hand secondHand = new Hand();
 
-        List<Card> cards = getCardsInHand().getCards();
-        Card newDeckCard = getCardsInHand().getCards().remove(cards.size() - 1);
+        List<Card> cards = handToSplit.getCards();
+        Card newDeckCard = cards.remove(cards.size() - 1);
 
         secondHand.addCard(newDeckCard);
 
-        this.cardsInHand.addCard(game.getDeck().deal());
+        handToSplit.addCard(game.getDeck().deal());
         secondHand.addCard(game.getDeck().deal());
 
-        this.splitPlay.add(cardsInHand);
+        if (splitPlay.isEmpty()) {
+            this.splitPlay.add(handToSplit);
+        }
         this.splitPlay.add(secondHand);
 
         return secondHand;
@@ -162,8 +163,8 @@ public class Player {
     public void manageBet() {
         this.setIsChoosingBet(true);
 
-        String betRequest = GenerateJson.generateBetRequest(name, "Starting amount: $" + money + "\n" +
-                "Please choose a bet amount: ");
+        String betRequest = GenerateJson.generateBetRequest(name, "Current balance: $" + (int) money + "\n" +
+                "Place your bet (min $1, max $" + (int) money + "): ");
         playerManager.sendMessage(betRequest);
 
         boolean betting = true;
@@ -262,8 +263,7 @@ public class Player {
 
     public void removeBet() {
         this.money -= bet;
-        playerManager.sendMessage(GenerateJson.generateGeneralMessage("You have placed a bet of $" + bet + "\n" +
-                "Money remaining: " + money));
+        playerManager.sendMessage(GenerateJson.generateGeneralMessage("Bet placed: $" + (int) bet + "  |  Balance: $" + (int) money));
     }
 
     public void surrenderPayout() {
@@ -271,27 +271,23 @@ public class Player {
     }
 
     public void winBet() {
-        this.money += 2*bet;
-        playerManager.sendMessage(GenerateJson.generateGeneralMessage("You won. \n" +
-                "Money remaining: " + money));
+        this.money += 2 * bet;
+        playerManager.sendMessage(GenerateJson.generateGeneralMessage("You win — $" + (int)(2 * bet) + " returned  |  Balance: $" + (int) money));
     }
 
     public void pushBet() {
         this.money += bet;
-        playerManager.sendMessage(GenerateJson.generateGeneralMessage("You pushed. \n" +
-                "Money remaining: " + money));
+        playerManager.sendMessage(GenerateJson.generateGeneralMessage("Push — bet returned: $" + (int) bet + "  |  Balance: $" + (int) money));
     }
 
     public void loseBet() {
-        playerManager.sendMessage(GenerateJson.generateGeneralMessage("You lost your bet.\n" +
-                "Money remaining: " + money));
+        playerManager.sendMessage(GenerateJson.generateGeneralMessage("You lost $" + (int) bet + ".  |  Balance: $" + (int) money));
     }
 
     public void blackJackPayout() {
-        double payout = bet + (1.5*bet);
+        double payout = bet + (1.5 * bet);
         this.money += payout;
-        playerManager.sendMessage(GenerateJson.generateGeneralMessage("Payout: $" + payout + "\n" +
-                "Money remaining: $" + money));
+        playerManager.sendMessage(GenerateJson.generateGeneralMessage("Blackjack! Payout: $" + (int) payout + "  |  Balance: $" + (int) money));
     }
 
     public Hand getCardsInHand() {

--- a/src/main/java/blackjack/player/state/Normal.java
+++ b/src/main/java/blackjack/player/state/Normal.java
@@ -21,7 +21,7 @@ public class Normal implements handState {
         List<BlackJackAction> availableActions =
                 new ArrayList<>(List.of(new DoubleAction(), new HitAction(), new StandAction(), new SurrenderAction()));
 
-        if (canSplit(hand) && !hand.isBeanSplit()) {
+        if (canSplit(hand)) {
             availableActions.add(new SplitAction());
         }
 

--- a/src/main/java/blackjack/protocol/GenerateJson.java
+++ b/src/main/java/blackjack/protocol/GenerateJson.java
@@ -89,9 +89,10 @@ public class GenerateJson {
     /**
      * Generates an update of the entire state of the game.
      * @param game --> the game to generate an update of.
+     * @param hideHoleCard --> true during player turns (hole card hidden), false once dealer reveals.
      * @return the string json form
      */
-    public static String generateUpdate(Play game) {
+    public static String generateUpdate(Play game, boolean hideHoleCard) {
         JsonNodeFactory factory = JsonNodeFactory.instance;
         ObjectNode rootNode = new ObjectNode(factory);
         List<Player> playersInGame = game.getPlayers();
@@ -103,7 +104,7 @@ public class GenerateJson {
         rootNode.put("protocolType", "update");
         rootNode.put("currentPlayer", game.getCurrentPlayer().getName());
         rootNode.set("players", playerObjectNode);
-        rootNode.set("dealer", dealerInformation(game));
+        rootNode.set("dealer", dealerInformation(game, hideHoleCard));
 
         return rootNode.toString();
     }
@@ -133,21 +134,32 @@ public class GenerateJson {
 
     /**
      * Generate an ObjectNode that represents the dealer's current state in the game.
+     * When hideHoleCard is true, only the face-up card is revealed — standard blackjack rules.
      * @param game --> the game that the dealer is currently in.
+     * @param hideHoleCard --> true during player turns; false when the dealer reveals.
      * @return the object node.
      */
-    private static ObjectNode dealerInformation(Play game) {
+    private static ObjectNode dealerInformation(Play game, boolean hideHoleCard) {
         JsonNodeFactory factory = JsonNodeFactory.instance;
         ObjectNode rootNode = new ObjectNode(factory);
         Dealer dealer = game.getDealer();
         List<Card> cardList = dealer.getCardsInHand().getCards();
         ArrayNode cardArrayNode = new ArrayNode(factory);
-        for (Card card : cardList) {
-            cardArrayNode.add(card.toString());
+
+        if (hideHoleCard && cardList.size() >= 2) {
+            cardArrayNode.add(cardList.get(0).toString());
+            cardArrayNode.add("[hidden]");
+            rootNode.put("state", "?");
+            rootNode.set("hand", cardArrayNode);
+            rootNode.put("handValue", cardList.get(0).getValue());
+        } else {
+            for (Card card : cardList) {
+                cardArrayNode.add(card.toString());
+            }
+            rootNode.put("state", dealer.getCardsInHand().getState().toString());
+            rootNode.set("hand", cardArrayNode);
+            rootNode.put("handValue", dealer.getHandValue());
         }
-        rootNode.put("state", dealer.getCardsInHand().getState().toString());
-        rootNode.set("hand", cardArrayNode);
-        rootNode.put("handValue", dealer.getHandValue());
 
         return rootNode;
     }

--- a/src/test/java/blackjack/protocol/DecryptClientTests.java
+++ b/src/test/java/blackjack/protocol/DecryptClientTests.java
@@ -72,7 +72,7 @@ public class DecryptClientTests {
         fred.getCardsInHand().addCard(new Card(Deck.SUITS[0], Deck.RANKS[0]));
         greg.getCardsInHand().addCard(new Card(Deck.SUITS[0], Deck.RANKS[2]));
 
-        String updateRequest = GenerateJson.generateUpdate(game);
+        String updateRequest = GenerateJson.generateUpdate(game, false);
         JsonNode updateRequestNode = Decrypt.decryptServerMessage(updateRequest);
         String turnMessage = Decrypt.getTurn(updateRequestNode);
         String fredCards = Decrypt.getPlayerCardInfo(updateRequestNode, "fred");

--- a/src/test/java/blackjack/protocol/GenerateJsonServerTests.java
+++ b/src/test/java/blackjack/protocol/GenerateJsonServerTests.java
@@ -95,7 +95,7 @@ public class GenerateJsonServerTests {
         romeo.getCardsInHand().addCard(new Card(Deck.SUITS[0], Deck.RANKS[2]));
         dealer.getCardsInHand().addCard(new Card(Deck.SUITS[0], Deck.RANKS[10]));
 
-        String jsonString = GenerateJson.generateUpdate(game);
+        String jsonString = GenerateJson.generateUpdate(game, false);
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(jsonString);
 


### PR DESCRIPTION
- Rewrite client Decrypt to render a formatted table of all players and dealer on each update; hide dealer hole card during player turns
- Add pending-player queue so clients joining mid-round wait for the next round instead of corrupting the active one
- Fix SplitAction/splitHand to operate on the actively played hand rather than always cardsInHand; fix split-hand iteration in Play
- Fix payout logic: BlackJack vs BlackJack now correctly pushes; Surrender is settled by bustOrSurrendered, not determinePayout
- Fix PlayerManager game-start race condition with a synchronized block; add missing return after table-full close
- Improve action messages (hit/double/stand/split/surrender) using the shared formatHand helper on BlackJackAction
- Normalize client input (trim + lowercase) before sending actions/bets
- Add timing pauses between phases for readability
- Add CLAUDE.md with build commands, architecture overview, and known design issues